### PR TITLE
feat!: rename constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install stream-zip
 
 ```python
 from datetime import datetime
-from stream_zip import ZIP64, ZIP, NO_COMPRESSION, stream_zip
+from stream_zip import ZIP_64, ZIP_32, NO_COMPRESSION_32, stream_zip
 
 def unzipped_files():
     modified_at = datetime.now()
@@ -33,14 +33,14 @@ def unzipped_files():
     def file_3_data():
         yield b'Some bytes'
 
-    # ZIP64 mode
-    yield 'my-file-1.txt', modified_at, perms, ZIP64, file_1_data()
+    # ZIP_64 mode
+    yield 'my-file-1.txt', modified_at, perms, ZIP_64, file_1_data()
 
-    # ZIP mode
-    yield 'my-file-1.txt', modified_at, perms, ZIP, file_2_data()
+    # ZIP_32 mode
+    yield 'my-file-1.txt', modified_at, perms, ZIP_32, file_2_data()
 
     # No compression
-    yield 'my-file-2.txt', modified_at, perms, NO_COMPRESSION, file_3_data()
+    yield 'my-file-2.txt', modified_at, perms, NO_COMPRESSION_32, file_3_data()
 
 for zipped_chunk in stream_zip(unzipped_files()):
     print(zipped_chunk)
@@ -51,9 +51,9 @@ for zipped_chunk in stream_zip(unzipped_files()):
 
 It's not possible to _completely_ stream-write ZIP files. Small bits of metadata for each member file, such as its name, must be placed at the _end_ of the ZIP. In order to do this, stream-unzip buffers this metadata in memory until it can be output.
 
-No compression is supported via the `NO_COMPRESSION` constant as in the above examples. However in this case the entire contents of these are buffered in memory, and so this should not be used for large files. This is because for uncompressed data, its size and CRC32 must be _before_ it in the ZIP file.
+No compression is supported via the `NO_COMPRESSION_32` constant as in the above examples. However in this case the entire contents of these are buffered in memory, and so this should not be used for large files. This is because for uncompressed data, its size and CRC32 must be _before_ it in the ZIP file.
 
-It doesn't seem possible to automatically choose [ZIP64](https://en.wikipedia.org/wiki/ZIP_(file_format)#ZIP64) based on file sizes if streaming, since the specification of ZIP vs ZIP64 must be _before_ the compressed data of each file in the final stream, and so before the sizes are known. Hence the onus is on client code to choose. ZIP has greater support but is limited to 4GiB (gibibyte), while ZIP64 has less support, but has a much greater limit of 16EiB (exbibyte). These limits apply to the compressed size of each member file, the uncompressed size of each member file, and to the size of the entire archive.
+It doesn't seem possible to automatically choose [ZIP_64](https://en.wikipedia.org/wiki/ZIP_(file_format)#ZIP64) based on file sizes if streaming, since the specification of ZIP_32 vs ZIP_64 must be _before_ the compressed data of each file in the final stream, and so before the sizes are known. Hence the onus is on client code to choose. ZIP_32 has greater support but is limited to 4GiB (gibibyte), while ZIP_64 has less support, but has a much greater limit of 16EiB (exbibyte). These limits apply to the compressed size of each member file, the uncompressed size of each member file, and to the size of the entire archive.
 
 
 ## Exception hierarchy
@@ -72,12 +72,12 @@ It doesn't seem possible to automatically choose [ZIP64](https://en.wikipedia.or
 
         - **UncompressedSizeOverflowError**
 
-          The uncompressed size of the data is too large. The maximum uncompressed size for ZIP mode is 2^32 - 1 bytes, and for ZIP64 mode is 2^64 - 1 bytes.
+          The uncompressed size of the data is too large. The maximum uncompressed size for ZIP_32 mode is 2^32 - 1 bytes, and for ZIP_64 mode is 2^64 - 1 bytes.
 
         - **CompressedSizeOverflowError**
 
-          The compressed size of the data is too large. The maximum compressed size for ZIP mode is 2^32 - 1 bytes, and for ZIP64 mode is 2^64 - 1 bytes.
+          The compressed size of the data is too large. The maximum compressed size for ZIP_32 mode is 2^32 - 1 bytes, and for ZIP_64 mode is 2^64 - 1 bytes.
 
         - **OffsetOverflowError**
 
-          The offset of files in the archive is too high, i.e. the archive is too large. The limit for ZIP mode is 2^32 - 1 bytes, and for ZIP64 mode is 2^64 - 1 bytes.
+          The offset of files in the archive is too high, i.e. the archive is too large. The limit for ZIP_32 mode is 2^32 - 1 bytes, and for ZIP_64 mode is 2^64 - 1 bytes.


### PR DESCRIPTION
This is for clarity, and to allow in future having both NO_COMPRESSION_32 and NO_COMPRESSION_64, to allow clients to fully specify that they do not want any _64 code data.

Note that LibreOffice doesn't support zip64 at the time of writing, so this is still an issue. This is not just for "legacy" software.