### PR TITLE
feat: allow specification of zlib compressobj

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ for zipped_chunk in stream_zip(unzipped_files()):
 ```
 
 
+## Custom zlib options
+
+You can customise the compression object by overriding the default `get_compressobj` parameter, which is shown below.
+
+```python
+for zipped_chunk in stream_zip(unzipped_files(), get_compressobj=lambda: zlib.compressobj(wbits=-zlib.MAX_WBITS, level=9)):
+    print(zipped_chunk)
+```
+
+
 ## File-like object
 
 If you need a file-like object rather than an iterable yielding bytes, you can pass the return value of `stream_zip` through `to_file_like_obj` defined as below.
@@ -93,7 +103,11 @@ def to_file_like_obj(iterable):
 
 It's not possible to _completely_ stream-write ZIP files. Small bits of metadata for each member file, such as its name, must be placed at the _end_ of the ZIP. In order to do this, stream-zip buffers this metadata in memory until it can be output.
 
-No compression is supported via the `NO_COMPRESSION_*` constants as in the above examples. However in these cases the entire contents of each uncompressed file is buffered in memory, and so should not be used for large files. This is because for uncompressed data, its size and CRC32 must be _before_ it in the ZIP file.
+No compression is supported by two different mechanisms:
+
+- Using `NO_COMPRESSION_*` constants as in the above examples. However in these cases the entire contents of each uncompressed file is buffered in memory, and so should not be used for large files. This is because for raw uncompressed data, where the reader has no way of knowing when it gets to the end, its size and CRC32 must be _before_ it in the ZIP file.
+
+- Using `ZIP_*` constants, but passing `level=0` into a custom zlib compression object. This avoids the buffering into memory that `NO_COMPRESSION_*` will perform, but the output stream would be slightly larger. This is because the data will contain extra bytes every so often so it can indicate its end to the reader.
 
 It doesn't seem possible to automatically choose [ZIP_64](https://en.wikipedia.org/wiki/ZIP_(file_format)#ZIP64) based on file sizes if streaming, since the specification of ZIP_32 vs ZIP_64 must be _before_ the compressed data of each file in the final stream, and so before the sizes are known. Hence the onus is on client code to choose. ZIP_32 has greater support but is limited to 4GiB (gibibyte), while ZIP_64 has less support, but has a much greater limit of 16EiB (exbibyte). These limits apply to both the compressed and uncompressed sizes of each member file.
 

--- a/stream_zip.py
+++ b/stream_zip.py
@@ -7,7 +7,7 @@ NO_COMPRESSION_64 = object()
 ZIP_32 = object()
 ZIP_64 = object()
 
-def stream_zip(files, chunk_size=65536):
+def stream_zip(files, chunk_size=65536, get_compressobj=lambda: zlib.compressobj(wbits=-zlib.MAX_WBITS, level=9)):
 
     def evenly_sized(chunks):
         chunk = b''
@@ -186,7 +186,7 @@ def stream_zip(files, chunk_size=65536):
             uncompressed_size = 0
             compressed_size = 0
             crc_32 = zlib.crc32(b'')
-            compress_obj = zlib.compressobj(wbits=-zlib.MAX_WBITS, level=9)
+            compress_obj = get_compressobj()
             for chunk in chunks:
                 uncompressed_size += len(chunk)
 


### PR DESCRIPTION
This I think is a reasonable way of addressing the need for large files that should both not be buffered in memory, and not compressed, as reported in https://github.com/uktrade/stream-zip/issues/17