### PR TITLE
feat: no need for local zip64 extra when streaming

### DIFF
--- a/stream_zip.py
+++ b/stream_zip.py
@@ -80,12 +80,6 @@ def stream_zip(files, chunk_size=65536, get_compressobj=lambda: zlib.compressobj
 
             _raise_if_beyond(file_offset, maximum=0xffffffffffffffff, exception_class=OffsetOverflowError)
 
-            extra = zip_64_local_extra_struct.pack(
-                zip_64_extra_signature,
-                16,  # Size of extra
-                0,   # Uncompressed size - since data descriptor
-                0,   # Compressed size - since data descriptor
-            )
             yield from _(local_header_signature)
             yield from _(local_header_struct.pack(
                 45,           # Version
@@ -96,11 +90,9 @@ def stream_zip(files, chunk_size=65536, get_compressobj=lambda: zlib.compressobj
                 0xffffffff,   # Compressed size - since zip64
                 0xffffffff,   # Uncompressed size - since zip64
                 len(name_encoded),
-                len(extra),
+                0,            # Size of extra
             ))
             yield from _(name_encoded)
-            yield from _(extra)
-
             uncompressed_size, compressed_size, crc_32 = yield from _zip_data(
                 chunks,
                 max_uncompressed_size=0xffffffffffffffff,


### PR DESCRIPTION
This was added in https://github.com/uktrade/stream-zip/commit/62f8cf1ee242f7d9fe1467fe9a93b20164764068, but it might not really have ever been needed, so removing it saves a few bytes. And stronger than that, https://github.com/libarchive/libarchive/issues/1834 gives an argument that it even makes the ZIP file invalid.

To give even more weight to the argument that this is ok, I made a few Zip64 files with data descriptors with InfoZIP. They did not have local Zip64 extra fields. If this were a problem, it probably would have been discovered by now.