### PR TITLE
fix: 'Inappropriate file type or format' in Archive Utility and bsdcpio

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,10 @@ jobs:
         with:
           name: reporter
           path: ./reporter
-      - name: "Install dependencies"
+      - name: "Install bsdcpio"
+        run: |
+          ./install-libarachive.sh
+      - name: "Install python dependencies"
         run: |
           pip install -r requirements-dev.txt
           chmod +x ./reporter/cc-test-reporter

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+libarchive-*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,7 @@ Changes are then submitted via a Pull Request (PR). To do this:
 3. Make sure you can run existing tests locally
 
     ```bash
+    ./install-libarachive.sh             # Only needed once
     pip install -r requirements-dev.txt  # Only needed once
     pytest
     ```

--- a/install-libarachive.sh
+++ b/install-libarachive.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# This version is the one that comes with macOS, and behaves most similarly to its Archive Utility
+curl --output libarchive-3.5.3.tar.gz https://www.libarchive.org/downloads/libarchive-3.5.3.tar.gz
+echo "72788e5f58d16febddfa262a5215e05fc9c79f2670f641ac039e6df44330ef51 libarchive-3.5.3.tar.gz" | sha256sum --check
+tar -zxf libarchive-3.5.3.tar.gz
+(
+    cd libarchive-3.5.3
+    ./configure
+    make
+)


### PR DESCRIPTION
This reverts commit 1130fdcb5f8a068c194392fdf5b0d8b6769a8928, "feat: no need for local zip64 extra when streaming"

It was thought that there was no need for the ZIP_64 "extra" section in the local header. Tests ran fine without it, and there was an argument that having it made the ZIP file invalid at https://github.com/libarchive/libarchive/issues/1834. However, it was found in https://github.com/uktrade/stream-zip/issues/27 that it caused an error on OSX's Archive Utility:

> Error 79 - Inappropriate file type or format

and a very similar error in libarchive's bsdcpio

> cpio: Inconsistent uncompressed size: 12 in central directory, 4294967295 in local header: Inappropriate file type or format

or in some situations

> cpio: ZIP uncompressed data is wrong size (read 12, expected 0)