### PR TITLE
deps: support Python >= 3.7.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,13 +21,23 @@ jobs:
   test:
     name: Test
     needs: download
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:
-          - "3.7"
-          - "3.8"
-          - "3.9"
+        include:
+          # 3.7.1 is the earliest Python version available in actions/setup-python
+          - python-version: "3.7.1"
+            os: "ubuntu-20.04"
+          - python-version: "3.7"
+            os: "ubuntu-latest"
+          - python-version: "3.8.0"
+            os: "ubuntu-20.04"
+          - python-version: "3.8"
+            os: "ubuntu-latest"
+          - python-version: "3.9.0"
+            os: "ubuntu-20.04"
+          - python-version: "3.9"
+            os: "ubuntu-latest"
+    runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
@@ -70,5 +80,5 @@ jobs:
         run: |
           ls -R
           chmod +x ./reporter/cc-test-reporter
-          ./reporter/cc-test-reporter sum-coverage ./coverage/*.json -p 3
+          ./reporter/cc-test-reporter sum-coverage ./coverage/*.json -p 6
           ./reporter/cc-test-reporter upload-coverage

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Topic :: System :: Archiving :: Compression',
     ],
-    python_requires='>=3.7.4',
+    python_requires='>=3.7.1',
     py_modules=[
         'stream_zip',
     ],


### PR DESCRIPTION
Suspect this wasn't done earlier since it seemed tricky to test this version on CircleCI. However, it seems a bit easier on GitHub actions where the tests now run

https://github.com/uktrade/stream-zip/issues/32