### PR TITLE
fix: auto upgrade central directory if too many files in ZIP_AUTO mode

### DIFF
--- a/stream_zip.py
+++ b/stream_zip.py
@@ -400,6 +400,7 @@ def stream_zip(files, chunk_size=65536, get_compressobj=lambda: zlib.compressobj
 
             zip_64_central_directory = zip_64_central_directory \
                 or (_auto_upgrade_central_directory is _AUTO_UPGRADE_CENTRAL_DIRECTORY and offset > 0xffffffff) \
+                or (_auto_upgrade_central_directory is _AUTO_UPGRADE_CENTRAL_DIRECTORY and len(central_directory) > 0xffff) \
                 or _method in (_ZIP_64, _NO_COMPRESSION_64)
 
         max_central_directory_length, max_central_directory_start_offset, max_central_directory_size = \


### PR DESCRIPTION
This was missed from previous work on ZIP_AUTO mode.

There is still one value that is not auto upgraded to Zip64 - central_directory_size. But this limit is 4GiB in Zip32, which is pretty enormous for a central directory. I think it's fine to leave that for now.