### PR TITLE
docs: change perms to mode, mode to method, and document how to make empty directories and symbolic links

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,13 +1,13 @@
 ## Custom zlib options
 
-For the `ZIP_32` or `ZIP_64` modes, you can customise the compression object by overriding the default `get_compressobj` parameter, which is shown below.
+For the `ZIP_32` or `ZIP_64` methods, you can customise the compression object by overriding the default `get_compressobj` parameter, which is shown below.
 
 ```python
 for zipped_chunk in stream_zip(unzipped_files(), get_compressobj=lambda: zlib.compressobj(wbits=-zlib.MAX_WBITS, level=9)):
     print(zipped_chunk)
 ```
 
-If you wish to disable compression entirely for these modes, you can pass `level=0` in the above. There is no way to customize the zlib object for `ZIP_AUTO` mode, other than passing `level` into it. See [Modes](modes.md) for details and other ways to not compress member files.
+If you wish to disable compression entirely for these methods, you can pass `level=0` in the above. There is no way to customize the zlib object for the `ZIP_AUTO` method, other than passing `level` into it. See [Methods](methods.md) for details and other ways to not compress member files.
 
 
 ## Custom chunk size

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -14,7 +14,7 @@ Exceptions raised by the source iterables are passed through the `stream_zip` fu
 
           - **ZipOverflowError** (also inherits from the **OverflowError** built-in)
 
-            The size or positions of data in the ZIP are too large to store using the requested mode
+            The size or positions of data in the ZIP are too large to store using the requested method
 
             - **UncompressedSizeOverflowError**
 

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -14,36 +14,32 @@ Exceptions raised by the source iterables are passed through the `stream_zip` fu
 
           - **ZipOverflowError** (also inherits from the **OverflowError** built-in)
 
-            The size or positions of data in the ZIP are too large to store in the requested mode
+            The size or positions of data in the ZIP are too large to store using the requested mode
 
             - **UncompressedSizeOverflowError**
 
-                The uncompressed size of a member file is too large. The maximum uncompressed size for ZIP_32 mode is 2^32 - 1 bytes, and for ZIP_64 mode is 2^64 - 1 bytes.
+                The uncompressed size of a member file is too large. For a `*_32` member file the maximum uncompressed size is 2^32 - 1 bytes, and for a `*_64` member file the maximum uncompressed size is 2^64 - 1 bytes.
 
             - **CompressedSizeOverflowError**
 
-                The compressed size of a member file is too large. The maximum compressed size for ZIP_32 mode is 2^32 - 1 bytes, and for ZIP_64 mode is 2^64 - 1 bytes.
+                The compressed size of a member file is too large. For a `*_32` member file the maximum compressed size is 2^32 - 1 bytes, and for a `*_64` member file the maximum compressed size is 2^64 - 1 bytes.
 
             - **CentralDirectorySizeOverflowError**
 
-                The size of the central directory, a section at the end of the ZIP that lists all the member files. The maximum size for ZIP_32 mode is 2^32 - 1 bytes, and for ZIP_64 mode is 2^64 - 1 bytes.
-
-                If any `_64` mode files are in the ZIP, the central directory is in ZIP_64 mode, and ZIP_32 mode otherwise.
+                The central directory, a section at the end of the ZIP that lists all the member files, is too large. The maximum size of the central directory if there are only `*_32` member files is 2^32 - 1 bytes. If there are any `*_64` member files the maximum size is 2^64 - 1 bytes.
 
             - **CentralDirectoryNumberOfEntriesOverflowError**
 
-                Too many entries in the central directory, a section at the end of the ZIP that lists all the member files. The limit for ZIP_32 mode is 2^16 - 1 entries, and for ZIP_64 mode is 2^64 - 1 entries.
-
-                If any `_64` mode files are in the ZIP, the central directory is in ZIP_64 mode, and ZIP_32 mode otherwise.
+                The central directory, a section at the end of the ZIP that lists all the member files, has too many entries. If there are only `*_32` member files the maximum number of entries is 2^16 - 1. If there are any `*_64` member files, the maximum number of entries is 2^64 - 1.
 
             - **OffsetOverflowError**
 
-                The offset of data in the ZIP is too high, i.e. the ZIP is too large. The limit for ZIP_32 mode is 2^32 - 1 bytes, and for ZIP_64 mode is 2^64 - 1 bytes.
+                The offset of data in the ZIP is too high, i.e. the ZIP is too large. If there are only `*_32` member files the maximum offset is 2^32 - 1 bytes. If there are any `*_64` member files the maximum offset is 2^64 - 1 bytes.
 
-                This can be raised when stream-zip adds member files, or when it adds the central directory at the end of the ZIP file. If any `_64` mode files are in the ZIP, the central directory is in ZIP_64 mode, and ZIP_32 mode otherwise.
+                This can be raised when stream-zip adds member files, or when it adds the central directory at the end of the ZIP file.
 
-                It is possible for the ZIP file to be larger than the maximum allowed offset without this exception being thrown. For example in ZIP_32 mode the archive can can be larger than 2^32 - 1 bytes.
+                Due to the nature of the ZIP file format, it is possible for the ZIP file to be larger than the maximum allowed offset without this exception being thrown. For example, even if there are only `*_32` member files, the archive can be larger than 2^32 - 1 bytes.
 
             - **NameLengthOverflowError**
 
-                The length of a file name is too high. The limit is 2^16 - 1 bytes, and applied to file names after UTF-8 encoding.
+                The length of a file name is too high. The limit is 2^16 - 1 bytes, and applied to file names after UTF-8 encoding. This is the limit whether or not there are any `*_64` member files.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,6 +110,19 @@ for zipped_chunk in zipped_chunks:
 This pattern of generators is typical for stream-unzip. Depending on how the generators are defined, it allows avoiding loading all the bytes of member files into memory at once.
 
 
+## Symbolic links
+
+Symbolic links can be stored in ZIP files. The mode must have `stat.S_IFLNK`, and the binary contents of the file must be the path to the target of the symbolic link.
+
+```python
+from datetime import datetime
+from stat import S_IFLNK
+from stream_zip import ZIP_32
+
+link = ('source.txt', datetime.now(), S_IFLNK | 0o600, ZIP_32, (b'target.txt',))
+```
+
+
 ## Methods
 
 Each member file is compressed with a method that must be specified in client code. See [Methods](methods.md) for an explanation of each.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -123,6 +123,23 @@ link = ('source.txt', datetime.now(), S_IFLNK | 0o600, ZIP_32, (b'target.txt',))
 ```
 
 
+## Directories
+
+Directories can be stored in ZIP files as empty member files whose name ends with a forward slash `/` that also have `stat.S_IFDIR` in the mode.
+
+```python
+from datetime import datetime
+from stat import S_IFDIR
+from stream_zip import ZIP_32
+
+directory = ('my-dir/', datetime.now(), S_IFDIR | 0o700, ZIP_32, ())
+```
+
+The `stat.S_IFDIR` on the file is technically optional, but is probably good practice since it will match the resulting directory after extraction. The permissions on the directory, in the above case `0o700`, are not preserved by all clients on extraction.
+
+It is not required to have a directory member file in order to have files in that directory. So this pattern is most useful to have empty directories in the ZIP.
+
+
 ## Methods
 
 Each member file is compressed with a method that must be specified in client code. See [Methods](methods.md) for an explanation of each.

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -1,24 +1,24 @@
-# Modes
+# Methods
 
-Each member file of the ZIP must be one of the following modes.
+Each member file of the ZIP is compressed with one following methods.
 
 
 ## ZIP_32, NO_COMPRESSION_32
 
-These modes are the historical standard modes for ZIP files.
+These methods are the historical standard methods for ZIP files.
 
 `ZIP_32` compresses the file by default, but it is affected the `get_compressobj` parameter to `stream_unzip`. For example, by passing `get_compressobj=lambda: zlib.compressobj(wbits=-zlib.MAX_WBITS, level=0)`, the `level=0` part would result in this file not being compressed. Its size would increase slightly due to overhead of the underlying algorithm.
 
 `NO_COMPRESSION_32` does not compress the member file, and is not affected by the `get_compressobj` parameter to `stream_unzip`. However, its entire contents is buffered in memory before output begins, and so should not be used for large files. It size does not increase - in the final ZIP file the contents of each `NO_COMPRESSION_32` member file is present byte-for-byte.
 
-Each member file is limited to 4GiB (gibibyte). This limitation is on the uncompressed size of the data, and (if `ZIP_32`) the compressed size of the data, and how far the start of the member file is from the beginning in the final ZIP file. A `ZIP_32` or `NO_COMPRESSION_32` file can also not be later than the 65,535th member file in a ZIP. If a file only has `ZIP_32` or `NO_COMPRESSION_32` members, the entire file is in Zip32 mode, and end of the final member file must be less than 4GiB from the beginning of the final ZIP. If these limits are breached, a `ZipOverflowError` will be raised.
+Each member file is limited to 4GiB (gibibyte). This limitation is on the uncompressed size of the data, and (if `ZIP_32`) the compressed size of the data, and how far the start of the member file is from the beginning in the final ZIP file. A `ZIP_32` or `NO_COMPRESSION_32` file can also not be later than the 65,535th member file in a ZIP. If a file only has `ZIP_32` or `NO_COMPRESSION_32` members, the entire file is a Zip32 file, and end of the final member file must be less than 4GiB from the beginning of the final ZIP. If these limits are breached, a `ZipOverflowError` will be raised.
 
 This has very high support. You can usually assume anything that can open a ZIP file can open ZIP files with only `ZIP_32` or `NO_COMPRESSION_32` members.
 
 
 ## ZIP_64, NO_COMPRESSION_64
 
-These modes use the Zip64 extension to the original ZIP format.
+These methods use the Zip64 extension to the original ZIP format.
 
 `ZIP_64` compresses the file by default, but it is affected the `get_compressobj` parameter to `stream_unzip`. For example, by passing `get_compressobj=lambda: zlib.compressobj(wbits=-zlib.MAX_WBITS, level=0)`, the `level=0` part would result in this file not being compressed. However, its size would increase slightly due to overhead of the underlying algorithm.
 
@@ -34,6 +34,6 @@ Support is limited to newer clients. However, at the time of writing there are t
 
 ## ZIP_AUTO(uncompressed_size, level=9)
 
-This dynamic mode chooses `ZIP_32` if it is sure a `ZipOverflowError` won't occur with its lower limits, but chooses `ZIP_64` otherwise. It uses the required parameter of `uncompressed_size`, as well as other more under the hood details, such as how far the member file would appear from the start of the ZIP file.
+This dynamic method chooses `ZIP_32` if it is sure a `ZipOverflowError` won't occur with its lower limits, but chooses `ZIP_64` otherwise. It uses the required parameter of `uncompressed_size`, as well as other more under the hood details, such as how far the member file would appear from the start of the ZIP file.
 
 Compression level can be changed by overwriting the `level` parameter. Specifically, passing `level=0` disables compresion for this member file, but its size would increase slightly due to the overhead of the underlying algorithm. It is not affected by the `get_compressobj` parameter to `stream_unzip`.

--- a/stream_zip.py
+++ b/stream_zip.py
@@ -375,7 +375,7 @@ def stream_zip(files, chunk_size=65536, get_compressobj=lambda: zlib.compressobj
 
             return chunks, size, crc_32
 
-        for name, modified_at, perms, method, chunks in files:
+        for name, modified_at, mode, method, chunks in files:
             _method, _auto_upgrade_central_directory, _get_compress_obj = method(offset, get_compressobj)
 
             name_encoded = name.encode('utf-8')
@@ -390,7 +390,7 @@ def stream_zip(files, chunk_size=65536, get_compressobj=lambda: zlib.compressobj
                 (modified_at.year - 1980) << 9,
             )
             external_attr = \
-                (perms << 16) | \
+                (mode << 16) | \
                 (0x10 if name_encoded[-1:] == b'/' else 0x0)  # MS-DOS directory
 
             data_func = \

--- a/test_stream_zip.py
+++ b/test_stream_zip.py
@@ -46,11 +46,11 @@ def gen_bytes(num):
 
 def test_with_stream_unzip_zip_64():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_64, (b'a' * 10000, b'b' * 10000)
-        yield 'file-2', now, perms, ZIP_64, (b'c', b'd')
+        yield 'file-1', now, mode, ZIP_64, (b'a' * 10000, b'b' * 10000)
+        yield 'file-2', now, mode, ZIP_64, (b'c', b'd')
 
     assert [(b'file-1', None, b'a' * 10000 + b'b' * 10000), (b'file-2', None, b'cd')] == [
         (name, size, b''.join(chunks))
@@ -60,11 +60,11 @@ def test_with_stream_unzip_zip_64():
 
 def test_with_stream_unzip_zip_32():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_32, (b'a' * 10000, b'b' * 10000)
-        yield 'file-2', now, perms, ZIP_32, (b'c', b'd')
+        yield 'file-1', now, mode, ZIP_32, (b'a' * 10000, b'b' * 10000)
+        yield 'file-2', now, mode, ZIP_32, (b'c', b'd')
 
     assert [(b'file-1', None, b'a' * 10000 + b'b' * 10000), (b'file-2', None, b'cd')] == [
         (name, size, b''.join(chunks))
@@ -74,11 +74,11 @@ def test_with_stream_unzip_zip_32():
 
 def test_with_stream_unzip_zip_32_and_zip_64():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_64, (b'a' * 10000, b'b' * 10000)
-        yield 'file-2', now, perms, ZIP_32, (b'c', b'd')
+        yield 'file-1', now, mode, ZIP_64, (b'a' * 10000, b'b' * 10000)
+        yield 'file-2', now, mode, ZIP_32, (b'c', b'd')
 
     assert [(b'file-1', None, b'a' * 10000 + b'b' * 10000), (b'file-2', None, b'cd')] == [
         (name, size, b''.join(chunks))
@@ -88,11 +88,11 @@ def test_with_stream_unzip_zip_32_and_zip_64():
 
 def test_with_stream_unzip_with_no_compresion_32():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, NO_COMPRESSION_32, (b'a' * 10000, b'b' * 10000)
-        yield 'file-2', now, perms, NO_COMPRESSION_32, (b'c', b'd')
+        yield 'file-1', now, mode, NO_COMPRESSION_32, (b'a' * 10000, b'b' * 10000)
+        yield 'file-2', now, mode, NO_COMPRESSION_32, (b'c', b'd')
 
     assert [(b'file-1', 20000, b'a' * 10000 + b'b' * 10000), (b'file-2', 2, b'cd')] == [
         (name, size, b''.join(chunks))
@@ -102,11 +102,11 @@ def test_with_stream_unzip_with_no_compresion_32():
 
 def test_with_stream_unzip_auto_small():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_AUTO(20000), (b'a' * 10000, b'b' * 10000)
-        yield 'file-2', now, perms, ZIP_AUTO(2), (b'c', b'd')
+        yield 'file-1', now, mode, ZIP_AUTO(20000), (b'a' * 10000, b'b' * 10000)
+        yield 'file-2', now, mode, ZIP_AUTO(2), (b'c', b'd')
 
     assert [(b'file-1', None, b'a' * 10000 + b'b' * 10000), (b'file-2', None, b'cd')] == [
         (name, size, b''.join(chunks))
@@ -123,10 +123,10 @@ def test_with_stream_unzip_auto_small():
 )
 def test_with_stream_unzip_at_zip_32_limit(level):
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_AUTO(4293656841, level=level), gen_bytes(4293656841)
+        yield 'file-1', now, mode, ZIP_AUTO(4293656841, level=level), gen_bytes(4293656841)
 
     assert [(b'file-1', None, 4293656841)] == [
         (name, size, sum(len(chunk) for chunk in chunks))
@@ -143,10 +143,10 @@ def test_with_stream_unzip_at_zip_32_limit(level):
 )
 def test_with_stream_unzip_above_zip_32_size_limit(level):
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_AUTO(4293656842, level=level), gen_bytes(4293656842)
+        yield 'file-1', now, mode, ZIP_AUTO(4293656842, level=level), gen_bytes(4293656842)
 
     assert [(b'file-1', None, 4293656842)] == [
         (name, size, sum(len(chunk) for chunk in chunks))
@@ -159,12 +159,12 @@ def test_with_stream_unzip_above_zip_32_size_limit(level):
 
 def test_with_stream_unzip_above_zip_32_offset_limit():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_AUTO(4000000000, level=0), gen_bytes(4000000000)
-        yield 'file-2', now, perms, ZIP_AUTO(4000000000, level=0), gen_bytes(4000000000)
-        yield 'file-3', now, perms, ZIP_AUTO(1, level=0), gen_bytes(1)
+        yield 'file-1', now, mode, ZIP_AUTO(4000000000, level=0), gen_bytes(4000000000)
+        yield 'file-2', now, mode, ZIP_AUTO(4000000000, level=0), gen_bytes(4000000000)
+        yield 'file-3', now, mode, ZIP_AUTO(1, level=0), gen_bytes(1)
 
     assert [(b'file-1', None, 4000000000), (b'file-2', None, 4000000000), (b'file-3', None, 1)] == [
         (name, size, sum(len(chunk) for chunk in chunks))
@@ -191,7 +191,7 @@ def test_with_stream_unzip_above_zip_32_offset_limit():
 
 def test_with_stream_unzip_large_easily_compressible():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
     batch = b'-' * 500000
 
     def files():
@@ -199,7 +199,7 @@ def test_with_stream_unzip_large_easily_compressible():
             for i in range(0, 10000):
                 yield batch
 
-        yield 'file-1', now, perms, ZIP_64, data()
+        yield 'file-1', now, mode, ZIP_64, data()
 
     num_received = 0
     for name, size, chunks in stream_unzip(stream_zip(files())):
@@ -211,7 +211,7 @@ def test_with_stream_unzip_large_easily_compressible():
 
 def test_with_stream_unzip_large_not_easily_compressible_with_no_compression_64():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
     batch = os.urandom(500000)
 
     def files():
@@ -219,8 +219,8 @@ def test_with_stream_unzip_large_not_easily_compressible_with_no_compression_64(
             for i in range(0, 10000):
                 yield batch
 
-        yield 'file-1', now, perms, ZIP_64, data()
-        yield 'file-2', now, perms, NO_COMPRESSION_64, (b'-',)
+        yield 'file-1', now, mode, ZIP_64, data()
+        yield 'file-2', now, mode, NO_COMPRESSION_64, (b'-',)
 
     num_received = 0
     for name, size, chunks in stream_unzip(stream_zip(files())):
@@ -232,7 +232,7 @@ def test_with_stream_unzip_large_not_easily_compressible_with_no_compression_64(
 
 def test_with_stream_unzip_large_not_easily_compressible_with_no_compression_32():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
     batch = os.urandom(500000)
 
     def files():
@@ -240,8 +240,8 @@ def test_with_stream_unzip_large_not_easily_compressible_with_no_compression_32(
             for i in range(0, 10000):
                 yield batch
 
-        yield 'file-1', now, perms, ZIP_64, data()
-        yield 'file-2', now, perms, NO_COMPRESSION_32, (b'-',)
+        yield 'file-1', now, mode, ZIP_64, data()
+        yield 'file-2', now, mode, NO_COMPRESSION_32, (b'-',)
 
     with pytest.raises(OffsetOverflowError):
         for name, size, chunks in stream_unzip(stream_zip(files())):
@@ -251,7 +251,7 @@ def test_with_stream_unzip_large_not_easily_compressible_with_no_compression_32(
 
 def test_with_stream_unzip_large_not_easily_compressible_with_zip_32():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = 0o600
     batch = os.urandom(500000)
 
     def files():
@@ -259,8 +259,8 @@ def test_with_stream_unzip_large_not_easily_compressible_with_zip_32():
             for i in range(0, 10000):
                 yield batch
 
-        yield 'file-1', now, perms, ZIP_64, data()
-        yield 'file-2', now, perms, ZIP_32, (b'-',)  # Needs a ZIP_64 offset, but is in ZIP_32 mode
+        yield 'file-1', now, mode, ZIP_64, data()
+        yield 'file-2', now, mode, ZIP_32, (b'-',)  # Needs a ZIP_64 offset, but is in ZIP_32 mode
 
     with pytest.raises(OffsetOverflowError):
         for name, size, chunks in stream_unzip(stream_zip(files())):
@@ -270,7 +270,7 @@ def test_with_stream_unzip_large_not_easily_compressible_with_zip_32():
 
 def test_zip_overflow_large_not_easily_compressible():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
     batch = os.urandom(500000)
 
     def files():
@@ -278,7 +278,7 @@ def test_zip_overflow_large_not_easily_compressible():
             for i in range(0, 10000):
                 yield batch
 
-        yield 'file-1', now, perms, ZIP_32, data()
+        yield 'file-1', now, mode, ZIP_32, data()
 
     with pytest.raises(CompressedSizeOverflowError):
         for chunk in stream_zip(files()):
@@ -287,7 +287,7 @@ def test_zip_overflow_large_not_easily_compressible():
 
 def test_zip_overflow_large_easily_compressible():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
     batch = b'-' * 1000000
 
     def files():
@@ -295,7 +295,7 @@ def test_zip_overflow_large_easily_compressible():
             for i in range(0, 10000):
                 yield batch
 
-        yield 'file-1', now, perms, ZIP_32, data()
+        yield 'file-1', now, mode, ZIP_32, data()
 
     with pytest.raises(UncompressedSizeOverflowError):
         for chunk in stream_zip(files()):
@@ -304,11 +304,11 @@ def test_zip_overflow_large_easily_compressible():
 
 def test_with_zipfile_zip_64():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1 🍰', now, perms, ZIP_64, (b'a' * 10000, b'b' * 10000)
-        yield 'file-2 🍰', now, perms, ZIP_64, (b'c', b'd')
+        yield 'file-1 🍰', now, mode, ZIP_64, (b'a' * 10000, b'b' * 10000)
+        yield 'file-2 🍰', now, mode, ZIP_64, (b'c', b'd')
 
     def extracted():
         with ZipFile(BytesIO(b''.join(stream_zip(files())))) as my_zip:
@@ -326,24 +326,24 @@ def test_with_zipfile_zip_64():
         'file-1 🍰',
         20000,
         (2021, 1, 1, 21, 1, 12),
-        perms << 16,
+        mode << 16,
         b'a' * 10000 + b'b' * 10000,
     ), (
         'file-2 🍰',
         2,
         (2021, 1, 1, 21, 1, 12),
-        perms << 16,
+        mode << 16,
         b'cd',
     )] == list(extracted())
 
 
 def test_with_zipfile_zip_32():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_32, (b'a' * 10000, b'b' * 10000)
-        yield 'file-2', now, perms, ZIP_32, (b'c', b'd')
+        yield 'file-1', now, mode, ZIP_32, (b'a' * 10000, b'b' * 10000)
+        yield 'file-2', now, mode, ZIP_32, (b'c', b'd')
 
     def extracted():
         with ZipFile(BytesIO(b''.join(stream_zip(files())))) as my_zip:
@@ -361,24 +361,24 @@ def test_with_zipfile_zip_32():
         'file-1',
         20000,
         (2021, 1, 1, 21, 1, 12),
-        perms << 16,
+        mode << 16,
         b'a' * 10000 + b'b' * 10000,
     ), (
         'file-2',
         2,
         (2021, 1, 1, 21, 1, 12),
-        perms << 16,
+        mode << 16,
         b'cd',
     )] == list(extracted())
 
 
 def test_with_zipfile_zip_32_and_zip_64():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_64, (b'a' * 10000, b'b' * 10000)
-        yield 'file-2', now, perms, ZIP_32, (b'c', b'd')
+        yield 'file-1', now, mode, ZIP_64, (b'a' * 10000, b'b' * 10000)
+        yield 'file-2', now, mode, ZIP_32, (b'c', b'd')
 
     def extracted():
         with ZipFile(BytesIO(b''.join(stream_zip(files())))) as my_zip:
@@ -396,24 +396,24 @@ def test_with_zipfile_zip_32_and_zip_64():
         'file-1',
         20000,
         (2021, 1, 1, 21, 1, 12),
-        perms << 16,
+        mode << 16,
         b'a' * 10000 + b'b' * 10000,
     ), (
         'file-2',
         2,
         (2021, 1, 1, 21, 1, 12),
-        perms << 16,
+        mode << 16,
         b'cd',
     )] == list(extracted())
 
 
 def test_with_zipfile_without_compression():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, NO_COMPRESSION_32, (b'a' * 10000, b'b' * 10000)
-        yield 'file-2', now, perms, NO_COMPRESSION_32, (b'c', b'd')
+        yield 'file-1', now, mode, NO_COMPRESSION_32, (b'a' * 10000, b'b' * 10000)
+        yield 'file-2', now, mode, NO_COMPRESSION_32, (b'c', b'd')
 
     def extracted():
         with ZipFile(BytesIO(b''.join(stream_zip(files())))) as my_zip:
@@ -431,24 +431,24 @@ def test_with_zipfile_without_compression():
         'file-1',
         20000,
         (2021, 1, 1, 21, 1, 12),
-        perms << 16,
+        mode << 16,
         b'a' * 10000 + b'b' * 10000,
     ), (
         'file-2',
         2,
         (2021, 1, 1, 21, 1, 12),
-        perms << 16,
+        mode << 16,
         b'cd',
     )] == list(extracted())
 
 
 def test_with_zipfile_many_files_zip_64():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
         for i in range(0, 100000):
-            yield f'file-{i}', now, perms, ZIP_64, (b'ab',)
+            yield f'file-{i}', now, mode, ZIP_64, (b'ab',)
 
     def extracted():
         with ZipFile(BytesIO(b''.join(stream_zip(files())))) as my_zip:
@@ -470,11 +470,11 @@ def test_with_zipfile_no_files():
 
 def test_too_many_files_for_zip_32_raises_exception_in_zip_32_mode():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
         for i in range(0, 0xffff + 1):
-            yield f'file-{i}', now, perms, ZIP_32, (b'ab',)
+            yield f'file-{i}', now, mode, ZIP_32, (b'ab',)
 
     with pytest.raises(CentralDirectoryNumberOfEntriesOverflowError):
         for chunk in stream_zip(files()):
@@ -483,11 +483,11 @@ def test_too_many_files_for_zip_32_raises_exception_in_zip_32_mode():
 
 def test_too_many_files_for_zip_32_no_exception_in_auto_mode():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
         for i in range(0, 0xffff + 1):
-            yield f'file-{i}', now, perms, ZIP_AUTO(2), (b'ab',)
+            yield f'file-{i}', now, mode, ZIP_AUTO(2), (b'ab',)
 
     num_files = 0
     for _, __, chunks in stream_unzip(stream_zip(files())):
@@ -500,11 +500,11 @@ def test_too_many_files_for_zip_32_no_exception_in_auto_mode():
 
 def test_central_directory_size_overflow():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
         for i in range(0, 0xffff):
-            yield str(i).zfill(5) + '-' * 65502, now, perms, NO_COMPRESSION_32, (b'',)
+            yield str(i).zfill(5) + '-' * 65502, now, mode, NO_COMPRESSION_32, (b'',)
 
     with pytest.raises(CentralDirectorySizeOverflowError):
         for chunk in stream_zip(files()):
@@ -513,11 +513,11 @@ def test_central_directory_size_overflow():
 
 def test_directory_zipfile():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_64, (b'a' * 10000, b'b' * 10000)
-        yield 'file-2/', now, perms, ZIP_64, ()
+        yield 'file-1', now, mode, ZIP_64, (b'a' * 10000, b'b' * 10000)
+        yield 'file-2/', now, mode, ZIP_64, ()
 
     def extracted():
         with ZipFile(BytesIO(b''.join(stream_zip(files())))) as my_zip:
@@ -535,24 +535,24 @@ def test_directory_zipfile():
         'file-1',
         20000,
         (2021, 1, 1, 21, 1, 12),
-        perms << 16,
+        mode << 16,
         b'a' * 10000 + b'b' * 10000,
     ), (
         'file-2/',
         0,
         (2021, 1, 1, 21, 1, 12),
-        perms << 16 | 0x10,
+        mode << 16 | 0x10,
         b'',
     )] == list(extracted())
 
 
 def test_with_unzip_zip64():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_64, (b'a' * 10000, b'b' * 10000)
-        yield 'file-2', now, perms, ZIP_64, (b'c', b'd')
+        yield 'file-1', now, mode, ZIP_64, (b'a' * 10000, b'b' * 10000)
+        yield 'file-2', now, mode, ZIP_64, (b'c', b'd')
 
     def extracted():
         with TemporaryDirectory() as d:
@@ -577,11 +577,11 @@ def test_with_unzip_zip64():
 
 def test_with_unzip_zip_32_and_zip_64():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_64, (b'a' * 10000, b'b' * 10000)
-        yield 'file-2', now, perms, ZIP_32, (b'c', b'd')
+        yield 'file-1', now, mode, ZIP_64, (b'a' * 10000, b'b' * 10000)
+        yield 'file-2', now, mode, ZIP_32, (b'c', b'd')
 
     def extracted():
         with TemporaryDirectory() as d:
@@ -606,11 +606,11 @@ def test_with_unzip_zip_32_and_zip_64():
 
 def test_with_unzip_with_no_compression_32():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, NO_COMPRESSION_32, (b'a' * 10000, b'b' * 10000)
-        yield 'file-2', now, perms, NO_COMPRESSION_32, (b'c', b'd')
+        yield 'file-1', now, mode, NO_COMPRESSION_32, (b'a' * 10000, b'b' * 10000)
+        yield 'file-2', now, mode, NO_COMPRESSION_32, (b'c', b'd')
 
     def extracted():
         with TemporaryDirectory() as d:
@@ -635,10 +635,10 @@ def test_with_unzip_with_no_compression_32():
 
 def test_name_length_overflow():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield '-' * (2**16), now, perms, ZIP_64, (b'ab',)
+        yield '-' * (2**16), now, mode, ZIP_64, (b'ab',)
 
     with pytest.raises(NameLengthOverflowError):
         for chunk in stream_zip(files()):
@@ -647,10 +647,10 @@ def test_name_length_overflow():
 
 def test_exception_propagates():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_64, (b'a' * 10000, b'b' * 10000)
+        yield 'file-1', now, mode, ZIP_64, (b'a' * 10000, b'b' * 10000)
         raise Exception('From generator')
 
     with pytest.raises(Exception,  match='From generator'):
@@ -660,14 +660,14 @@ def test_exception_propagates():
 
 def test_exception_from_bytes_propagates():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def data():
         yield b'-'
         raise Exception('From generator')
 
     def files():
-        yield 'file-1', now, perms, ZIP_64, data()
+        yield 'file-1', now, mode, ZIP_64, data()
 
     with pytest.raises(Exception,  match='From generator'):
         for chunk in stream_zip(files()):
@@ -676,10 +676,10 @@ def test_exception_from_bytes_propagates():
 
 def test_chunk_sizes():
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
 
     def files():
-        yield 'file-1', now, perms, ZIP_64, (os.urandom(500000),)
+        yield 'file-1', now, mode, ZIP_64, (os.urandom(500000),)
 
     def get_sizes():
         for chunk in stream_zip(files()):
@@ -701,9 +701,9 @@ def test_bsdcpio(method):
     assert method in (ZIP_32, ZIP_64)  # Paranoia check that parameterisation works
 
     now = datetime.fromisoformat('2021-01-01 21:01:12')
-    perms = 0o600
+    mode = stat.S_IFREG | 0o600
     zip_bytes = b''.join(stream_zip((
-        ('file-1', now, perms, method, (b'contents',)),
+        ('file-1', now, mode, method, (b'contents',)),
     )))
 
     def read(path):
@@ -737,7 +737,7 @@ def test_bsdcpio(method):
 def test_7z_symbolic_link(method):
     modified_at = datetime.now()
     member_files = (
-        ('my-file-1.txt', modified_at, 0o600, ZIP_64, (b'Some bytes 1',)),
+        ('my-file-1.txt', modified_at, stat.S_IFREG | 0o600, ZIP_64, (b'Some bytes 1',)),
         ('my-link.txt', modified_at, stat.S_IFLNK | 0o600, ZIP_64, (b'my-file-1.txt',)),
     )
     zipped_chunks = stream_zip(member_files)


### PR DESCRIPTION
This is inspired by https://github.com/uktrade/stream-zip/issues/55 and https://github.com/uktrade/stream-zip/pull/56 that describe issues with storing empty directories. However, rather than any behaviour change, this PR slightly refactors code and (hopefully) improves documentation regarding what was known as the perms/permissions option, and how to make empty directories.

The perms/permissions option is more accurately a "mode", as in, the unix/linux file mode, that describes not only permissions, but the type of file, e.g. regular file, directory, or symbolic link. Since this is now "mode", what was the "mode", the ZIP_32/ZIP-64-ness of member files is now known as the "method". This was already "method" in some of the code, and is more consistent with APPNOTE.

The tests in this PR document that clients are very not consistent with what they do with the mode, which is a bit of a shame.

As a sidebar, I realise that having a "tuple-based" API means that this sort of thing can be done without a breaking change :-) 