### PR TITLE
docs: add badge to condo-forge package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- --8<-- [start:intro] -->
 # stream-zip
 
-[![PyPI package](https://img.shields.io/pypi/v/stream-zip?label=PyPI%20package&color=%234c1)](https://pypi.org/project/stream-zip/) [![Test suite](https://img.shields.io/github/actions/workflow/status/uktrade/stream-zip/test.yml?label=Test%20suite)](https://github.com/uktrade/stream-zip/actions/workflows/test.yml) [![Code coverage](https://img.shields.io/codecov/c/github/uktrade/stream-zip?label=Code%20coverage)](https://app.codecov.io/gh/uktrade/stream-zip)
+[![conda-forge package](https://img.shields.io/conda/v/conda-forge/stream-zip?label=conda-forge&color=%234c1)](https://anaconda.org/conda-forge/stream-zip) [![PyPI package](https://img.shields.io/pypi/v/stream-zip?label=PyPI%20package&color=%234c1)](https://pypi.org/project/stream-zip/) [![Test suite](https://img.shields.io/github/actions/workflow/status/uktrade/stream-zip/test.yml?label=Test%20suite)](https://github.com/uktrade/stream-zip/actions/workflows/test.yml) [![Code coverage](https://img.shields.io/codecov/c/github/uktrade/stream-zip?label=Code%20coverage)](https://app.codecov.io/gh/uktrade/stream-zip)
 
 Python function to construct a ZIP archive on the fly - without having to store the entire ZIP in memory or disk. This is useful in memory-constrained environments, or when you would like to start returning compressed data before you've even retrieved all the uncompressed data. Generating ZIPs on-demand in a web server is a typical use case for stream-zip.
 


### PR DESCRIPTION
This adds a badge showing the current package version on conda-forge, with a link to it at https://anaconda.org/conda-forge/stream-zip

<img width="541" alt="Screenshot 2023-11-29 at 07 33 10" src="https://github.com/uktrade/stream-zip/assets/13877/7ce09098-72ed-46f9-92b6-28c62879c028">


stream-zip has been recently added to conda-forge via https://github.com/conda-forge/staged-recipes/pull/24588, with its feedstock repo at https://github.com/conda-forge/stream-zip-feedstock, so this is done for slightly easier discoverability that it's on conda forge and an option for users.

This is also done for consistency with the sibling project, stream-unzip, which has a badge at the top of its README at https://github.com/uktrade/stream-unzip