### PR TITLE
docs: be explicit on the underlying encryption used when password protecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In addition to being memory efficient (with some [limitations](https://stream-zi
 
 - Can construct ZIP files that contain directories, including empty directories
 
-- Can construct password protected/encrypted ZIP files adhering to the [WinZip AE-2 specification](https://www.winzip.com/en/support/aes-encryption/).
+- Can construct password protected / AES-256 encrypted ZIP files adhering to the [WinZip AE-2 specification](https://www.winzip.com/en/support/aes-encryption/).
 
 - Allows the specification of permissions on the member files and directories (although not all clients respect them)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -14,7 +14,7 @@ In addition to being memory efficient (with some [limitations](/get-started/#lim
 
 - Can construct ZIP files that contain directories, including empty directories
 
-- Can construct password protected/encrypted ZIP files adhering to the [WinZip AE-2 specification](https://www.winzip.com/en/support/aes-encryption/).
+- Can construct password protected / AES-256 encrypted ZIP files adhering to the [WinZip AE-2 specification](https://www.winzip.com/en/support/aes-encryption/).
 
 - Allows the specification of permissions on the member files and directories (although not all clients respect them)
 


### PR DESCRIPTION
This mentions AES-256 in the feature list so it's very clear that this isn't ZipCrypto up front, as well as the encryption strength, and to hint that the encryption strength is not configurable, so people aren't surprised.