### PR TITLE
docs: add order of 0 to index/homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@ homepage: true
 layout: product
 title: Construct ZIP files on the fly
 description: Use this Python package to output compressed ZIP files while receiving the uncompressed input
+order: 0
 startButton:
   href: "get-started"
   text: Get started


### PR DESCRIPTION
This adds the order of 0 to the index/homepage

It's a speculative attempt to fix the slightly non-deterministic sort order of _non_ homepages.