### PR TITLE
docs: use system font, and fix layout of header

### DIFF
--- a/docs/sass/_settings.scss
+++ b/docs/sass/_settings.scss
@@ -1,0 +1,8 @@
+$govuk-font-family: system-ui, sans-serif;
+
+// Our logo is 5px taller than the GOV.UK Crown that the design system is tailored for. But it's
+// only sort of "peeking" beyond the edges so we don't allocate more space for it in the page.
+// The X-GOVUK site doing a very similar thing with its logo I think for a similar reason
+.dbt-header__logotype {
+	margin-bottom: -5px;
+}


### PR DESCRIPTION
This was incorrectly left out of the commit at 48b625b60bf6bd7d02380ea9084eefbb73c6dfca

It:

- Uses system-ui rather than the GDS Transport font, which I think we shouldn't be using since this isn't a GOV.UK services
- Fixes height/spacing in the header