### PR TITLE
feat: async interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ In addition to being memory efficient (with some [limitations](https://stream-zi
 
 - By default stores modification time as an extended timestamp. An extended timestamp is a more accurate timestamp than the original ZIP format allows
 
+- Provides an async interface (that uses threads under the hood to share code with the sync interface without blocking the event loop)
+
 <!-- --8<-- [end:features] -->
 
 ---

--- a/docs/async-interface.md
+++ b/docs/async-interface.md
@@ -5,69 +5,54 @@ title: Async interface
 ---
 
 
-stream-zip does not include an async interface. However, it is possible to construct an async function that wraps stream-zip to allow the construction of zip files in a streaming way from async code without blocking the event loop.
+An async interface is provided via the function `async_stream_zip`. Its usage is exactly the same as `stream_zip` except that:
 
-```python
-import asyncio
-from stream_zip import stream_zip
-
-async def async_stream_zip(member_files, *args, **kwargs):
-
-    async def to_async_iterable(sync_iterable):
-        # to_thread errors if StopIteration raised in it. So we use a sentinel to detect the end
-        done = object()
-        it = iter(sync_iterable)
-        while (value := await asyncio.to_thread(next, it, done)) is not done:
-            yield value
-
-    def to_sync_iterable(async_iterable):
-        done = object()
-        async_it = aiter(async_iterable)
-        while (value := asyncio.run_coroutine_threadsafe(anext(async_it, done), loop).result()) is not done:
-            yield value
-
-    loop = asyncio.get_running_loop()
-    sync_member_files = (
-        member_file[0:4] + (to_sync_iterable(member_file[4],),)
-        for member_file in to_sync_iterable(member_files)
-    )
-
-    async for chunk in to_async_iterable(stream_zip(sync_member_files, *args, **kwargs)):
-        yield chunk
-```
-
-The above allows the member files to be supplied by an async iterable, and the data of each member file to be supplied by an async iterable.
+1. The member files must be provided as an async iterable of tuples.
+2. The data of each member file must be provided as an async iterable of bytes.
+3. Its return value is an async iterable of bytes.
 
 ```python
 from datetime import datetime
 from stat import S_IFREG
-from stream_zip import ZIP_32
+from stream_zip import async_stream_zip, ZIP_32
 
 # Hard coded for example purposes
-async def get_async_data():
+async def async_data():
     yield b'Some bytes 1'
     yield b'Some bytes 2'
 
 # Hard coded for example purposes
-async def get_async_member_files():
+async def async_member_files():
     yield (
         'my-file-1.txt',     
         datetime.now(),      
         S_IFREG | 0o600,
         ZIP_32,              
-        get_async_data(),
+        async_data(),
     )
     yield (
         'my-file-2.txt',     
         datetime.now(),      
         S_IFREG | 0o600,
         ZIP_32,              
-        get_async_data(),
+        async_data(),
     )
 
 async def main():
-    async for chunk in async_stream_zip(get_async_member_files()):
+    async for chunk in async_stream_zip(async_member_files()):
         print(chunk)
 
 asyncio.run(main())
 ```
+
+> ### Warnings
+>
+> Under the hood `async_stream_zip` uses threads as a layer over the synchronous `stream_zip` function. This has two consequences:
+>
+> 1. A possible performance penalty over a theoretical implementation that is pure async without threads.
+>
+> 2. The [contextvars](https://docs.python.org/3/library/contextvars.html) context available in the async iterables of files or data is a shallow copy of the context where async_stream_zip is called from.
+>
+>   This means that existing context variables are available inside the iterables, but any changes made to the context itself from inside the iterables will not propagate out to the original context. Changes made to mutable data structures that are part of the context, for example dictionaries, will propagate out.
+>
+>   This does not affect Python 3.6, because contextvars is not available.

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,3 +19,5 @@ In addition to being memory efficient (with some [limitations](/get-started/#lim
 - Allows the specification of permissions on the member files and directories (although not all clients respect them)
 
 - By default stores modification time as an extended timestamp. An extended timestamp is a more accurate timestamp than the original ZIP format allows
+
+- Provides an async interface (that uses threads under the hood to share code with the sync interface without blocking the event loop)


### PR DESCRIPTION
This brings the async example from the documentation into the codebase proper.

This is inspired by the PR and conversation at https://github.com/uktrade/stream-unzip/pull/80. To avoid duplication, threads are used to use the sync code without blocking the event loop.