### PR TITLE
feat: type annotations now allow strict type checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           pip install ".[ci]"
       - name: "Run type checking"
         run: |
-          mypy stream_zip.py
+          mypy stream_zip.py --strict
       - name: "Run tests"
         run: |
           pytest --cov

--- a/stream_zip.py
+++ b/stream_zip.py
@@ -251,7 +251,7 @@ def stream_zip(files: Iterable[MemberFile], chunk_size: int=65536,
                 mod_at_unix_extra: bytes, aes_extra: bytes, external_attr: int, uncompressed_size: int, crc_32: int,
                 crc_32_mask: int, _get_compress_obj: _CompressObjGetter, encryption_func: Callable[[Generator[bytes, None, Any]], Generator[bytes, None, Any]],
                 chunks: Iterable[bytes],
-        ) -> Generator[bytes, None, Any]:
+        ) -> Generator[bytes, None, Tuple[bytes, bytes, bytes]]:
             file_offset = offset
 
             _raise_if_beyond(file_offset, maximum=0xffffffffffffffff, exception_class=OffsetOverflowError)
@@ -323,7 +323,7 @@ def stream_zip(files: Iterable[MemberFile], chunk_size: int=65536,
                 mod_at_unix_extra: bytes, aes_extra: bytes, external_attr: int, uncompressed_size: int, crc_32: int,
                 crc_32_mask: int, _get_compress_obj: _CompressObjGetter, encryption_func: Callable[[Generator[bytes, None, Any]], Generator[bytes, None, Any]],
                 chunks: Iterable[bytes],
-        ) -> Generator[bytes, None, Any]:
+        ) -> Generator[bytes, None, Tuple[bytes, bytes, bytes]]:
             file_offset = offset
 
             _raise_if_beyond(file_offset, maximum=0xffffffff, exception_class=OffsetOverflowError)
@@ -411,7 +411,7 @@ def stream_zip(files: Iterable[MemberFile], chunk_size: int=65536,
                 mod_at_unix_extra: bytes, aes_extra: bytes, external_attr: int, uncompressed_size: int, crc_32: int,
                 crc_32_mask: int, _get_compress_obj: _CompressObjGetter, encryption_func: Callable[[Generator[bytes, None, Any]], Generator[bytes, None, Any]],
                 chunks: Iterable[bytes],
-        ) -> Generator[bytes, None, Any]:
+        ) -> Generator[bytes, None, Tuple[bytes, bytes, bytes]]:
             file_offset = offset
 
             _raise_if_beyond(file_offset, maximum=0xffffffffffffffff, exception_class=OffsetOverflowError)
@@ -478,7 +478,7 @@ def stream_zip(files: Iterable[MemberFile], chunk_size: int=65536,
                 mod_at_unix_extra: bytes, aes_extra: bytes, external_attr: int, uncompressed_size: int, crc_32: int,
                 crc_32_mask: int, _get_compress_obj: _CompressObjGetter, encryption_func: Callable[[Generator[bytes, None, Any]], Generator[bytes, None, Any]],
                 chunks: Iterable[bytes],
-        ) -> Generator[bytes, None, Any]:
+        ) -> Generator[bytes, None, Tuple[bytes, bytes, bytes]]:
             file_offset = offset
 
             _raise_if_beyond(file_offset, maximum=0xffffffff, exception_class=OffsetOverflowError)
@@ -551,7 +551,7 @@ def stream_zip(files: Iterable[MemberFile], chunk_size: int=65536,
                 mod_at_unix_extra: bytes, aes_extra: bytes, external_attr: int, uncompressed_size: int, crc_32: int,
                 crc_32_mask: int, _get_compress_obj: _CompressObjGetter, encryption_func: Callable[[Generator[bytes, None, Any]], Generator[bytes, None, Any]],
                 chunks: Iterable[bytes],
-        ) -> Generator[bytes, None, Any]:
+        ) -> Generator[bytes, None, Tuple[bytes, bytes, bytes]]:
             file_offset = offset
 
             _raise_if_beyond(file_offset, maximum=0xffffffffffffffff, exception_class=OffsetOverflowError)

--- a/stream_zip.py
+++ b/stream_zip.py
@@ -56,7 +56,7 @@ class _NO_COMPRESSION_32_TYPE(Method):
     def _get(self, offset: int, default_get_compressobj: _CompressObjGetter) -> _MethodTuple:
         return _NO_COMPRESSION_BUFFERED_32, _NO_AUTO_UPGRADE_CENTRAL_DIRECTORY, default_get_compressobj, 0, 0
 
-    def __call__(self, uncompressed_size: int, crc_32: int, *args: Any, **kwarg: Any) -> Method:
+    def __call__(self, uncompressed_size: int, crc_32: int) -> Method:
         class _NO_COMPRESSION_32_TYPE_STREAMED_TYPE(Method):
             def _get(self, offset: int, default_get_compressobj: _CompressObjGetter) -> _MethodTuple:
                 return _NO_COMPRESSION_STREAMED_32, _NO_AUTO_UPGRADE_CENTRAL_DIRECTORY, default_get_compressobj, uncompressed_size, crc_32

--- a/stream_zip.py
+++ b/stream_zip.py
@@ -379,7 +379,7 @@ def stream_zip(files: Iterable[MemberFile], chunk_size: int=65536,
             ), name_encoded, extra
 
         def _zip_data(chunks: Iterable[bytes], _get_compress_obj: _CompressObjGetter,
-                      max_uncompressed_size: int, max_compressed_size: int) -> Generator[bytes, None, Any]:
+                      max_uncompressed_size: int, max_compressed_size: int) -> Generator[bytes, None, Tuple[int, int, int]]:
             uncompressed_size = 0
             compressed_size = 0
             crc_32 = zlib.crc32(b'')


### PR DESCRIPTION
This changes the internal tuple type to make the uncompressed size and crc_32 non optional ints which makes it possible to pass type checking without any ifs or casts. This is still slightly odd maybe because it means we hard code them to 0 when they're not used. A "better" structure might be to have some sort of more dynamic structure to avoid this - maybe multiple tuples or a more complex class. However, suspect this is still a small step forward since it allows strict type checking.