### PR TITLE
feat: avoid mypy errors about empty body of an abstract method

### DIFF
--- a/stream_zip/__init__.py
+++ b/stream_zip/__init__.py
@@ -41,6 +41,7 @@ _MethodTuple = Tuple[
 
 # A "Method" is an instance of a class that has a _get function that returns a _MethodTuple
 class Method(ABC):
+    @abstractmethod
     def _get(self, offset: int, default_get_compressobj: _CompressObjGetter) -> _MethodTuple:
         pass
 


### PR DESCRIPTION
Maybe could replace with with a custom Protocol in a later version, but this is the smallest step that sorts some type checking issues.