### PR TITLE
ci: release process now includes a file with the source, but modified with correct version

### DIFF
--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v3
         with:

--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -18,6 +18,14 @@ jobs:
         run: >-
           sed -i "s/0\\.0\\.0\\.dev0/${GITHUB_REF/refs\/tags\/v/}/g" pyproject.toml
 
+      # This makes it a touch easier/more robust to package for Debian
+      # See https://github.com/uktrade/stream-zip/issues/136
+      - name: Update release to include source code with version
+        run: |
+          tar --exclude='./.git' -czvf "${GITHUB_REF_NAME}.tar.gz" .
+          gh release upload "${GITHUB_REF_NAME}" "${GITHUB_REF_NAME}.tar.gz" "Source code (with release version)"
+          rm "${GITHUB_REF_NAME}.tar.gz"
+
       - run: |
           pip install build
           python -m build


### PR DESCRIPTION
The source does not actually include the correct release version to avoid having to change the source code based on the current or next version. While this is maybe odd, it makes releasing quite easy. However, as https://github.com/uktrade/stream-zip/issues/136 this makes it slightly harder to release for Debian.

So we make a version of the source code that has the correct release version, and add it to the GitHub release. This makes it so any tinkering with versions is just done in this repository.

Bumping the checkout version just by the by