### PR TITLE
ci: fix creating .tar.gz of source but versioned

### DIFF
--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -22,7 +22,8 @@ jobs:
       # See https://github.com/uktrade/stream-zip/issues/136
       - name: Update release to include source code with version
         run: |
-          tar --exclude='./.git' -czvf "${GITHUB_REF_NAME}.tar.gz" .
+          touch "${GITHUB_REF_NAME}.tar.gz"
+          tar --exclude='.git' --exclude='${GITHUB_REF_NAME}.tar.gz' -czvf "${GITHUB_REF_NAME}.tar.gz" .
           gh release upload "${GITHUB_REF_NAME}" "${GITHUB_REF_NAME}.tar.gz" "Source code (with release version)"
           rm "${GITHUB_REF_NAME}.tar.gz"
 


### PR DESCRIPTION
Getting an error from GitHub actions:

> tar: .: file changed as we read it

Which might be because the archive .tar.gz is being created in the directory being archived. Creating the file first and then excluding it should sort this.