### PR TITLE
tests: fix for release candidates (and test on more versions of Python)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,17 @@ jobs:
             os: "ubuntu-20.04"
           - python-version: "3.10.0"
             os: "ubuntu-20.04"
+          - python-version: "3.11.0"
+            os: "ubuntu-20.04"
+          - python-version: "3.12.0"
+            os: "ubuntu-20.04"
+          - python-version: "3.13.0-rc.2"
+            os: "ubuntu-20.04"
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
-      - uses: "actions/setup-python@v4"
+      - uses: "actions/setup-python@v5"
         with:
           python-version: '${{ matrix.python-version }}'
       - name: "Install bsdcpio"
@@ -47,7 +53,7 @@ jobs:
           )
       - name: "Install python dependencies"
         run: |
-          pip install ".[ci]"
+          pip install ".[dev,ci]"
       - name: "Run type checking"
         run: |
           mypy stream_zip --strict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,6 @@ dev = [
 ]
 ci = [
     "pycryptodome==3.10.1",
-    "coverage==6.2",
-    "pytest==7.0.1",
-    "pytest-cov==3.0.0",
     "stream-unzip==0.0.86",
     "pyzipper==0.3.6",
     # Type checking

--- a/test_stream_zip.py
+++ b/test_stream_zip.py
@@ -3,10 +3,10 @@ from io import BytesIO
 import asyncio
 import contextlib
 import os
-import platform
 import secrets
 import stat
 import subprocess
+import sys
 import zlib
 from tempfile import TemporaryDirectory
 from struct import Struct
@@ -1388,7 +1388,7 @@ def test_async_stream_zip_does_stream():
 
 
 @pytest.mark.skipif(
-    tuple(int(v) for v in platform.python_version().split('.')) < (3,7,0),
+    sys.version_info[:2] < (3,7,0),
     reason="contextvars are not supported before Python 3.7.0",
 )
 def test_copy_of_context_variable_available_in_iterable():


### PR DESCRIPTION
Fixes https://github.com/uktrade/stream-zip/issues/146

Includes loosening the constraints on versions used to run tests in CI (e.g. pytest, coverage) since the older versions don't seem to work on newer Python. Specifically, coverage 6.2 bombs out with an error on Python 3.11)