### PR TITLE
Fix spelling mistakes, whitespace error, and broken "Methods" links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,9 +75,9 @@ Changes are then submitted via a Pull Request (PR). To do this:
 5. Commit your change and push to your fork. Ideally the commit message will follow the [Conventional Commit specification](https://www.conventionalcommits.org/).
 
     ```bash
-    git add docs/recipies.md  # Repeat for each file changed
+    git add docs/recipes.md  # Repeat for each file changed
     git commit -m "docs: added a Django recipe"
-    gir push origin docs/add-django-recipe
+    git push origin docs/add-django-recipe
     ```
 
 6. Raise a PR at [https://github.com/uktrade/stream-zip/pulls](https://github.com/uktrade/stream-zip/pulls) against the `main` branch in stream-zip.
@@ -130,7 +130,7 @@ Changes are then submitted via a Pull Request (PR). To do this:
     ```bash
     git add stream_zip.py  # Repeat for each file changed
     git commit -m "feat: the bug description"
-    gir push origin fix/the-bug-description
+    git push origin fix/the-bug-description
     ```
 
 6. Raise a PR at [https://github.com/uktrade/stream-zip/pulls](https://github.com/uktrade/stream-zip/pulls) against the `main` branch in stream-zip.

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -59,4 +59,4 @@ Support is limited to newer clients. However, at the time of writing there are t
 
 This dynamic method chooses `ZIP_32` if it is sure a `ZipOverflowError` won't occur with its lower limits, but chooses `ZIP_64` otherwise. It uses the required parameter of `uncompressed_size`, as well as other more under the hood details, such as how far the member file would appear from the start of the ZIP file.
 
-Compression level can be changed by overwriting the `level` parameter. Specifically, passing `level=0` disables compresion for this member file, but its size would increase slightly due to the overhead of the underlying algorithm. It is not affected by the `get_compressobj` parameter to `stream_unzip`.
+Compression level can be changed by overwriting the `level` parameter. Specifically, passing `level=0` disables compression for this member file, but its size would increase slightly due to the overhead of the underlying algorithm. It is not affected by the `get_compressobj` parameter to `stream_unzip`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -80,9 +80,9 @@ Changes are then submitted via a Pull Request (PR). To do this:
 5. Commit your change and push to your fork. Ideally the commit message will follow the [Conventional Commit specification](https://www.conventionalcommits.org/).
 
     ```bash
-    git add docs/recipies.md  # Repeat for each file changed
+    git add docs/recipes.md  # Repeat for each file changed
     git commit -m "docs: added a Django recipe"
-    gir push origin docs/add-django-recipe
+    git push origin docs/add-django-recipe
     ```
 
 6. Raise a PR at [https://github.com/uktrade/stream-zip/pulls](https://github.com/uktrade/stream-zip/pulls) against the `main` branch in stream-zip.
@@ -135,7 +135,7 @@ Changes are then submitted via a Pull Request (PR). To do this:
     ```bash
     git add stream_zip.py  # Repeat for each file changed
     git commit -m "feat: the bug description"
-    gir push origin fix/the-bug-description
+    git push origin fix/the-bug-description
     ```
 
 6. Raise a PR at [https://github.com/uktrade/stream-zip/pulls](https://github.com/uktrade/stream-zip/pulls) against the `main` branch in stream-zip.

--- a/docs/contributing/publish-a-release.md
+++ b/docs/contributing/publish-a-release.md
@@ -9,7 +9,7 @@ title: How to publish a release
 ---
 
 
-Only mambers of the uktrade GitHub organisation may publish a release. If you are a member of the uktrade GitHub organsation:
+Only members of the uktrade GitHub organisation may publish a release. If you are a member of the uktrade GitHub organsation:
 
 1. Go to the [stream-zip GitHub releases page](https://github.com/uktrade/stream-zip/releases).
 

--- a/docs/get-started/advanced-usage.md
+++ b/docs/get-started/advanced-usage.md
@@ -18,7 +18,7 @@ for zipped_chunk in stream_zip(unzipped_files(), get_compressobj=lambda: zlib.co
     print(zipped_chunk)
 ```
 
-If you wish to disable compression entirely for these methods, you can pass `level=0` in the above. There is no way to customize the zlib object for the `ZIP_AUTO` method, other than passing `level` into it. See [Methods](/methods/) for details and other ways to not compress member files.
+If you wish to disable compression entirely for these methods, you can pass `level=0` in the above. There is no way to customize the zlib object for the `ZIP_AUTO` method, other than passing `level` into it. See [Compression methods](/api/methods/) for details and other ways to not compress member files.
 
 
 ## Custom chunk size

--- a/docs/get-started/limitations.md
+++ b/docs/get-started/limitations.md
@@ -11,6 +11,6 @@ title: Limitations
 
 The `NO_COMPRESSION_32` and `NO_COMPRESSION_64` methods do not stream - they buffer the entire binary contents of the file in memory before output. They do this to calculate the length and CRC 32 to output them before the binary contents in the ZIP. This is required in order for ZIP to be stream unzippable.
 
-However, if you are able to calculate the length and CRC 32 ahead of time, you can pass `NO_COMPRESSION_32(uncompressed_size, crc_32)` or`NO_COMPRESSION_64(uncompressed_size, crc_32)` as the method. These methods do not buffer the binary contents in memory, and so are streaming methods. See [Methods](/methods/) for details of all supported methods.
+However, if you are able to calculate the length and CRC 32 ahead of time, you can pass `NO_COMPRESSION_32(uncompressed_size, crc_32)` or `NO_COMPRESSION_64(uncompressed_size, crc_32)` as the method. These methods do not buffer the binary contents in memory, and so are streaming methods. See [Methods](/methods/) for details of all supported methods.
 
 Note that even for the streaming methods, it's not possible to _completely_ stream-write ZIP files. Small bits of metadata for each member file, such as its name, must be placed at the _end_ of the ZIP. In order to do this, stream-zip buffers this metadata in memory until it can be output. This is likely to only make a meaningful difference to memory usage for extremely high numbers of member files.

--- a/docs/get-started/limitations.md
+++ b/docs/get-started/limitations.md
@@ -11,6 +11,6 @@ title: Limitations
 
 The `NO_COMPRESSION_32` and `NO_COMPRESSION_64` methods do not stream - they buffer the entire binary contents of the file in memory before output. They do this to calculate the length and CRC 32 to output them before the binary contents in the ZIP. This is required in order for ZIP to be stream unzippable.
 
-However, if you are able to calculate the length and CRC 32 ahead of time, you can pass `NO_COMPRESSION_32(uncompressed_size, crc_32)` or `NO_COMPRESSION_64(uncompressed_size, crc_32)` as the method. These methods do not buffer the binary contents in memory, and so are streaming methods. See [Methods](/methods/) for details of all supported methods.
+However, if you are able to calculate the length and CRC 32 ahead of time, you can pass `NO_COMPRESSION_32(uncompressed_size, crc_32)` or `NO_COMPRESSION_64(uncompressed_size, crc_32)` as the method. These methods do not buffer the binary contents in memory, and so are streaming methods. See [Compression methods](/api/methods/) for details of all supported methods.
 
 Note that even for the streaming methods, it's not possible to _completely_ stream-write ZIP files. Small bits of metadata for each member file, such as its name, must be placed at the _end_ of the ZIP. In order to do this, stream-zip buffers this metadata in memory until it can be output. This is likely to only make a meaningful difference to memory usage for extremely high numbers of member files.

--- a/stream_zip/__init__.py
+++ b/stream_zip/__init__.py
@@ -96,7 +96,7 @@ class _ZIP_AUTO_TYPE():
 
         return _ZIP_AUTO_TYPE_INNER()
 
-# Sentinal object as a command that output buffer be flushed
+# Sentinel object as a command that output buffer be flushed
 # Extends from bytes to pass type checking
 class _Flusher(bytes):
     pass

--- a/test_stream_zip.py
+++ b/test_stream_zip.py
@@ -102,7 +102,7 @@ def test_with_stream_unzip_zip_32_and_zip_64():
     ]
 
 
-def test_with_stream_unzip_with_no_compresion_32():
+def test_with_stream_unzip_with_no_compression_32():
     now = datetime.strptime('2021-01-01 21:01:12', '%Y-%m-%d %H:%M:%S')
     mode = stat.S_IFREG | 0o600
 
@@ -123,7 +123,7 @@ def test_with_stream_unzip_with_no_compresion_32():
         NO_COMPRESSION_64,
     ],
 )
-def test_with_stream_unzip_with_no_compresion_known_crc_32(method):
+def test_with_stream_unzip_with_no_compression_known_crc_32(method):
     now = datetime.strptime('2021-01-01 21:01:12', '%Y-%m-%d %H:%M:%S')
     mode = stat.S_IFREG | 0o600
 
@@ -144,7 +144,7 @@ def test_with_stream_unzip_with_no_compresion_known_crc_32(method):
         NO_COMPRESSION_64,
     ],
 )
-def test_with_stream_unzip_with_no_compresion_bad_crc_32(method):
+def test_with_stream_unzip_with_no_compression_bad_crc_32(method):
     now = datetime.strptime('2021-01-01 21:01:12', '%Y-%m-%d %H:%M:%S')
     mode = stat.S_IFREG | 0o600
 
@@ -164,7 +164,7 @@ def test_with_stream_unzip_with_no_compresion_bad_crc_32(method):
         NO_COMPRESSION_64,
     ],
 )
-def test_with_stream_unzip_with_no_compresion_bad_size(method):
+def test_with_stream_unzip_with_no_compression_bad_size(method):
     now = datetime.strptime('2021-01-01 21:01:12', '%Y-%m-%d %H:%M:%S')
     mode = stat.S_IFREG | 0o600
 


### PR DESCRIPTION
# Description

I saw a couple things by hand and then ran `codespell`.

## Type of change

- [x] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

`pre-commit` ran successfully.  I was not yet able to actually look at the docs (#194).

No new automated tests required.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
