### PR TITLE
chore: Updating SRE contact email address (SR-4422)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "stream-zip"
 version = "0.0.0.dev0"
 authors = [
-  { name="Department for International Trade", email="sre@digital.trade.gov.uk" },
+  { name="Department for International Trade", email="sre@businessandtrade.gov.uk" },
 ]
 description = "Python function to construct a ZIP archive with stream processing - without having to store the entire ZIP in memory or disk"
 readme = "README.md"


### PR DESCRIPTION
Work as part of SRE Jira ticket: https://uktrade.atlassian.net/browse/SR-4422. PR to update any existing references to sre@digital.trade.gov.uk, due to the upcoming deprecatiion of this inbox. SRE contact email address has been updated to sre@businessandtrade.gov.uk.